### PR TITLE
Fixed import statements in example snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ redux-envelope --json-file swagger.json  --name myApp --version 1.0.0 --base-url
 ```js
 import { store, createStore, combineReducers } from "redux";
 
-import  {myAppReducer}  from "./sdk/reducer";
+import  { myAppReducer }  from "./sdk/reducer";
 
 store.createStore(combineReducers({ myAppReducer }));
 const disptach = store.dispatch;
@@ -35,7 +35,7 @@ export {dispatch};
 
 ```js
 import { dispatch } from "../redux";
-import MyApp from "./myApp.js";
+import MyApp from "./myApp";
 const myApp = new MyApp(dispatch, { requiedParams1: "" });
 export { myApp };
 ```
@@ -45,7 +45,7 @@ export { myApp };
 ```js
 import react from "react";
 import { myApp } from "./sdk";
-import connect from "react-redux";
+import { connect } from "react-redux";
 
 class App extends React.Component {
   componentDidMount() {

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ export { myApp };
 > in any component in your app for example `App.js`
 
 ```js
-import react from "react";
+import React from "react";
 import { myApp } from "./sdk";
 import { connect } from "react-redux";
 


### PR DESCRIPTION
- `connect` is not exported as default from `react-redux`, so updated the import accordingly.
- It's optional to give extension in import statement unless we have other files with same name, so changed `myApp.js` to `myApp`
